### PR TITLE
Add text input and modern design

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -21,10 +21,13 @@ os.makedirs(UPLOAD_DIR, exist_ok=True)
 # Página HTML principal
 @app.get("/", response_class=HTMLResponse)
 def form_page(request: Request):
-    return templates.TemplateResponse("index.html", {"request": request})
+    return templates.TemplateResponse(
+        "index.html",
+        {"request": request, "table_html": None, "download_url": None},
+    )
 
 # Endpoint para processar upload do Excel
-@app.post("/upload_excel/")
+@app.post("/upload_excel/", response_class=HTMLResponse)
 async def upload_excel(request: Request, file: UploadFile = File(...)):
     # Salvar arquivo temporariamente
     file_id = uuid.uuid4().hex
@@ -37,18 +40,37 @@ async def upload_excel(request: Request, file: UploadFile = File(...)):
     if "Resumo" not in df.columns:
         return {"erro": "Coluna 'Resumo' não encontrada no arquivo."}
 
-    # Processar sentimentos
-    from app.routes.sentiment import analisar_sentimento
-    resultados = df["Resumo"].fillna("").apply(analisar_sentimento)
+    # Processar sentimentos de forma otimizada em lote
+    from app.routes.sentiment import analisar_sentimentos_lote
+    textos = df["Resumo"].fillna("").tolist()
+    resultados = analisar_sentimentos_lote(textos)
     df["Sentimento"], df["Confianca"] = zip(*resultados)
 
-    # Salvar novo arquivo
-    output_path = os.path.join(UPLOAD_DIR, f"{file_id}_resultado.xlsx")
+    # Salvar novo arquivo para download posterior
+    output_filename = f"{file_id}_resultado.xlsx"
+    output_path = os.path.join(UPLOAD_DIR, output_filename)
     df.to_excel(output_path, index=False)
 
-    # Retornar arquivo para download
+    # Gerar HTML da tabela para exibir na página
+    table_html = df.to_html(classes="result-table", index=False)
+
+    # Exibir página com resultado e link para download
+    return templates.TemplateResponse(
+        "index.html",
+        {
+            "request": request,
+            "table_html": table_html,
+            "download_url": f"/download/{output_filename}"
+        },
+    )
+
+
+# Rota para download do arquivo processado
+@app.get("/download/{filename}")
+def download_file(filename: str):
+    file_path = os.path.join(UPLOAD_DIR, filename)
     return FileResponse(
-        path=output_path,
+        path=file_path,
         media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-        filename="resultado_sentimento.xlsx"
+        filename="resultado_sentimento.xlsx",
     )

--- a/app/routes/sentiment.py
+++ b/app/routes/sentiment.py
@@ -32,6 +32,20 @@ def analisar_sentimento(texto):
     confianca = round(resultado["score"], 4)
     return sentimento, confianca
 
+
+# 🔄 Função otimizada para processar vários textos de uma vez
+def analisar_sentimentos_lote(textos, batch_size: int = 16):
+    resultados_raw = sentiment_pipeline(
+        [t[:512] for t in textos], batch_size=batch_size, truncation=True
+    )
+    resultados_processados = []
+    for res in resultados_raw:
+        estrelas = int(res["label"][0])
+        sentimento = classificar_estrelas(estrelas - 1)
+        confianca = round(res["score"], 4)
+        resultados_processados.append((sentimento, confianca))
+    return resultados_processados
+
 # 🚀 Endpoint da API
 @router.post("/analise")
 def analise_sentimento(entrada: TextoEntrada):

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -9,29 +9,31 @@
       margin: 0;
       padding: 0;
       font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-      background: linear-gradient(to right, #1f1c2c, #928dab);
-      color: #fff;
+      background: linear-gradient(120deg, #1e3c72 0%, #2a5298 100%);
+      color: #333;
       display: flex;
-      align-items: center;
+      align-items: flex-start;
       justify-content: center;
-      height: 100vh;
+      min-height: 100vh;
+      padding: 40px 0;
     }
 
     .container {
-      background-color: rgba(255, 255, 255, 0.08);
+      background-color: rgba(255, 255, 255, 0.95);
       border-radius: 20px;
       padding: 40px;
       box-shadow: 0 12px 25px rgba(0, 0, 0, 0.3);
-      max-width: 500px;
+      max-width: 960px;
       width: 90%;
       text-align: center;
       backdrop-filter: blur(5px);
+      animation: fadeIn 1s ease;
     }
 
     h1 {
       font-size: 28px;
       margin-bottom: 20px;
-      color: #ffffff;
+      color: #1e3c72;
     }
 
     label {
@@ -41,7 +43,8 @@
       margin-bottom: 10px;
     }
 
-    input[type="file"] {
+    input[type="file"],
+    textarea {
       background: #fff;
       color: #333;
       padding: 10px;
@@ -53,7 +56,7 @@
     }
 
     button {
-      background: #00b894;
+      background: linear-gradient(120deg, #2196f3, #21cbf3);
       color: #fff;
       padding: 12px 30px;
       border: none;
@@ -62,10 +65,11 @@
       font-weight: bold;
       cursor: pointer;
       transition: all 0.3s ease;
+      margin-top: 10px;
     }
 
     button:hover {
-      background-color: #019875;
+      filter: brightness(0.9);
     }
 
     .loader {
@@ -78,7 +82,7 @@
       width: 10px;
       height: 10px;
       margin: 3px;
-      background: #00cec9;
+      background: #2196f3;
       border-radius: 50%;
       animation: loader 1.2s infinite ease-in-out both;
     }
@@ -95,11 +99,49 @@
     .footer {
       margin-top: 30px;
       font-size: 13px;
-      color: #ddd;
+      color: #555;
+    }
+
+    .table-container {
+      margin-top: 40px;
+      overflow-x: auto;
+      max-height: 60vh;
+    }
+
+    table.result-table {
+      border-collapse: collapse;
+      width: 100%;
+      background-color: rgba(255,255,255,0.9);
+      color: #333;
+    }
+
+    table.result-table th,
+    table.result-table td {
+      padding: 8px 12px;
+      border: 1px solid #ccc;
+    }
+
+    table.result-table th {
+      background-color: #2196f3;
+      color: #fff;
+    }
+
+    .download {
+      margin-top: 20px;
+    }
+
+    #text-result {
+      margin-top: 20px;
+      font-weight: 600;
     }
 
     .footer strong {
-      color: #00cec9;
+      color: #2196f3;
+    }
+
+    @keyframes fadeIn {
+      from { opacity: 0; transform: translateY(20px); }
+      to { opacity: 1; transform: translateY(0); }
     }
 
     @media (max-width: 480px) {
@@ -116,16 +158,36 @@
 <body>
   <div class="container">
     <h1>📊 Senticore - Análise de Sentimento</h1>
+
+    <form id="text-form">
+      <label for="texto">Digite uma mensagem:</label>
+      <textarea id="texto" name="texto" rows="3" required></textarea>
+      <button type="submit">💬 Analisar Texto</button>
+    </form>
+
+    <div id="text-result"></div>
+
     <form id="formulario" action="/upload_excel/" method="post" enctype="multipart/form-data">
       <label for="file">Selecione um arquivo Excel (.xlsx):</label>
       <input type="file" name="file" id="file" accept=".xlsx" required>
-      <button type="submit">📥 Analisar Sentimentos</button>
+      <button type="submit">📥 Analisar Arquivo</button>
     </form>
 
     <div class="loader" id="loader">
       <div></div><div></div><div></div>
       <p style="margin-top: 10px;">Analisando... por favor, aguarde</p>
     </div>
+
+    {% if table_html %}
+    <div class="download">
+      <a href="{{ download_url }}" target="_blank">
+        <button type="button">⬇️ Baixar Resultado</button>
+      </a>
+    </div>
+    <div class="table-container">
+      {{ table_html|safe }}
+    </div>
+    {% endif %}
 
     <div class="footer">
       Desenvolvido com ❤️ por <strong>Vinicius Santos</strong><br>
@@ -136,9 +198,35 @@
   <script>
     const form = document.getElementById('formulario');
     const loader = document.getElementById('loader');
+    const textForm = document.getElementById('text-form');
+    const textResult = document.getElementById('text-result');
 
     form.addEventListener('submit', () => {
       loader.style.display = 'block';
+    });
+
+    textForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      loader.style.display = 'block';
+      textResult.textContent = '';
+      const texto = document.getElementById('texto').value;
+      try {
+        const resp = await fetch('/analise', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ texto })
+        });
+        loader.style.display = 'none';
+        if (resp.ok) {
+          const data = await resp.json();
+          textResult.textContent = `Sentimento: ${data.sentimento} (confiança: ${data.confianca})`;
+        } else {
+          textResult.textContent = 'Erro ao analisar texto.';
+        }
+      } catch (err) {
+        loader.style.display = 'none';
+        textResult.textContent = 'Erro ao analisar texto.';
+      }
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- modernize the web page styling with a blue theme
- add textarea to analyze a single text using the API
- show results directly on the page and keep Excel upload

## Testing
- `python -m py_compile app/main.py app/routes/sentiment.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688551f0f160832eae61ed9277f239a9